### PR TITLE
Add support for LLaVa

### DIFF
--- a/alfresco_ai_assistant.py
+++ b/alfresco_ai_assistant.py
@@ -183,9 +183,7 @@ def describe_image(document_title: str, user_prompt: str) -> str:
     """Explain, describe, analyze an image. Requires the whole, unprocessed, user prompt/input."""
     document = get_document_content(document_title)
     image_b64 = base64.b64encode(document["content"]).decode("utf-8")
-    response = vision_llm.stream(user_prompt if user_prompt else "Describe the image.", images=[image_b64])
-    st.write_stream(response)
-    return None
+    return vision_llm.invoke(user_prompt if user_prompt else "Describe the image.", images=[image_b64])
 
 tools = [discovery, transform_content, translate_content, redact_content, list_recent_content_snippets, copy_file, create_pdf_report, describe_image]
 rendered_tools = render_text_description(tools)

--- a/alfresco_ai_assistant.py
+++ b/alfresco_ai_assistant.py
@@ -179,11 +179,11 @@ def create_pdf_report(document_title: str, document_text: str) -> str:
     return f'{document_title}.pdf created!'
 
 @tool
-def describe_image(document_title: str, user_request: str) -> str:
-    """Explain, describe, analyze an image. Requires the whole user request."""
+def describe_image(document_title: str, user_prompt: str) -> str:
+    """Explain, describe, analyze an image. Requires the whole, unprocessed, user prompt/input."""
     document = get_document_content(document_title)
     image_b64 = base64.b64encode(document["content"]).decode("utf-8")
-    return vision_llm.invoke(user_request if user_request else "Describe the image.", images=[image_b64])
+    return vision_llm.invoke(user_prompt if user_prompt else "Describe the image.", images=[image_b64])
 
 tools = [discovery, transform_content, translate_content, redact_content, list_recent_content_snippets, copy_file, create_pdf_report, describe_image]
 rendered_tools = render_text_description(tools)
@@ -206,6 +206,7 @@ example_messages = [
     ("user", "Redact all mentions of colors and names in 'snowwhite.docx'"), ("assistant", '{{"name": "redact_content", "arguments": {{"document_title": "snowwhite.docx", "user_request": "colors, names"}}}}'),
     ("user", "Show snippets of recent documents that contain the term 'contract'"), ("assistant", '{{"name": "list_recent_content_snippets", "arguments": {{"search_term": "contract"}}}}'),
     ("user", "Copy 'minutes.docx' to the 'Board Meetings' folder"), ("assistant", '{{"name": "copy_file", "arguments": {{"filename": "minutes.docx", "folder_name": "Board Meetings"}}}}'),
+    ("user", "Describe the techQuest_1.jpg image, provide a count of the people depicted in the image"), ("assistant", '{{"name": "describe_image", "arguments": {{"document_title": "techQuest_1.jpg", "user_prompt": "Describe the techQuest_1.jpg image, provide a count of the people depicted in the image"}}}}'),
     ("user", "Generate a pdf report about Alfresco Governance Services"), ("assistant", """{{"name": "create_pdf_report", "arguments": {{"document_title": "Alfresco Governance Services", "document_text": "Unlock the Power of Alfresco AGS
 
 Are you looking for a robust Records Management solution? Look no further than Alfresco AGS. With its advanced features, you can efficiently manage your organization's records and ensure compliance with regulatory requirements.

--- a/alfresco_ai_assistant.py
+++ b/alfresco_ai_assistant.py
@@ -183,7 +183,9 @@ def describe_image(document_title: str, user_prompt: str) -> str:
     """Explain, describe, analyze an image. Requires the whole, unprocessed, user prompt/input."""
     document = get_document_content(document_title)
     image_b64 = base64.b64encode(document["content"]).decode("utf-8")
-    return vision_llm.invoke(user_prompt if user_prompt else "Describe the image.", images=[image_b64])
+    response = vision_llm.stream(user_prompt if user_prompt else "Describe the image.", images=[image_b64])
+    st.write_stream(response)
+    return None
 
 tools = [discovery, transform_content, translate_content, redact_content, list_recent_content_snippets, copy_file, create_pdf_report, describe_image]
 rendered_tools = render_text_description(tools)

--- a/alfresco_api.py
+++ b/alfresco_api.py
@@ -49,7 +49,11 @@ class AlfrescoSearchAPI(AlfrescoAPI):
 class AlfrescoNodeAPI(AlfrescoAPI):
     def get_node_content(self, node_id: str):
         url = f"{self.base_url}/alfresco/api/-default-/public/alfresco/versions/1/nodes/{node_id}/content?attachment=false"
-        return requests.get(url, auth=self.auth).content.decode("utf-8")
+        content = requests.get(url, auth=self.auth).content
+        try:
+            return content.decode("utf-8")
+        except:
+            return content
 
     def upload_file(self, file_path: str, parent_id: str):
         url = f"{self.base_url}/alfresco/api/-default-/public/alfresco/versions/1/nodes/{parent_id}/children"

--- a/commons.py
+++ b/commons.py
@@ -7,6 +7,7 @@ from langchain_community.embeddings.sentence_transformer import SentenceTransfor
 from langchain_openai import ChatOpenAI
 from langchain_community.chat_models import ChatOllama
 from langchain_community.chat_models import BedrockChat
+from langchain_community.llms import Ollama
 
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 
@@ -58,6 +59,9 @@ def load_llm(llm_name: str, logger=BaseLogger(), config={}):
             model_kwargs={"temperature": 0.0, "max_tokens_to_sample": 1024},
             streaming=True,
         )
+    elif llm_name == "llava":
+        logger.info("LLM: Using Llava")
+        return Ollama(base_url=config["ollama_base_url"], model="llava")
     elif len(llm_name):
         logger.info(f"LLM: Using Ollama: {llm_name}")
         return ChatOllama(
@@ -68,7 +72,7 @@ def load_llm(llm_name: str, logger=BaseLogger(), config={}):
             # seed=2,
             top_k=10,  # A higher value (100) will give more diverse answers, while a lower value (10) will be more conservative.
             top_p=0.3,  # Higher value (0.95) will lead to more diverse text, while a lower value (0.5) will generate more focused text.
-            num_ctx=32768,  # Sets the size of the context window used to generate the next token.
+            num_ctx=3072,  # Sets the size of the context window used to generate the next token.
         )
     logger.info("LLM: Using GPT-3.5")
     return ChatOpenAI(temperature=0, model_name="gpt-3.5-turbo", streaming=True)

--- a/commons.py
+++ b/commons.py
@@ -61,7 +61,16 @@ def load_llm(llm_name: str, logger=BaseLogger(), config={}):
         )
     elif llm_name == "llava":
         logger.info("LLM: Using Llava")
-        return Ollama(base_url=config["ollama_base_url"], model="llava")
+        return ChatOllama(
+            temperature=0,
+            base_url=config["ollama_base_url"],
+            model="llava",
+            streaming=True,
+            # seed=2,
+            top_k=10,  # A higher value (100) will give more diverse answers, while a lower value (10) will be more conservative.
+            top_p=0.3,  # Higher value (0.95) will lead to more diverse text, while a lower value (0.5) will generate more focused text.
+            num_ctx=3072,  # Sets the size of the context window used to generate the next token.
+        )
     elif len(llm_name):
         logger.info(f"LLM: Using Ollama: {llm_name}")
         return ChatOllama(

--- a/commons.py
+++ b/commons.py
@@ -72,7 +72,7 @@ def load_llm(llm_name: str, logger=BaseLogger(), config={}):
             # seed=2,
             top_k=10,  # A higher value (100) will give more diverse answers, while a lower value (10) will be more conservative.
             top_p=0.3,  # Higher value (0.95) will lead to more diverse text, while a lower value (0.5) will generate more focused text.
-            num_ctx=3072,  # Sets the size of the context window used to generate the next token.
+            num_ctx=32768,  # Sets the size of the context window used to generate the next token.
         )
     logger.info("LLM: Using GPT-3.5")
     return ChatOpenAI(temperature=0, model_name="gpt-3.5-turbo", streaming=True)

--- a/commons.py
+++ b/commons.py
@@ -61,16 +61,7 @@ def load_llm(llm_name: str, logger=BaseLogger(), config={}):
         )
     elif llm_name == "llava":
         logger.info("LLM: Using Llava")
-        return ChatOllama(
-            temperature=0,
-            base_url=config["ollama_base_url"],
-            model="llava",
-            streaming=True,
-            # seed=2,
-            top_k=10,  # A higher value (100) will give more diverse answers, while a lower value (10) will be more conservative.
-            top_p=0.3,  # Higher value (0.95) will lead to more diverse text, while a lower value (0.5) will generate more focused text.
-            num_ctx=3072,  # Sets the size of the context window used to generate the next token.
-        )
+        return Ollama(base_url=config["ollama_base_url"], model="llava")
     elif len(llm_name):
         logger.info(f"LLM: Using Ollama: {llm_name}")
         return ChatOllama(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,16 @@ services:
       - LLM=${LLM-llama3}
     tty: true
 
+  pull-llava:
+    image: genai-stack/pull-model:latest
+    build:
+      context: .
+      dockerfile: pull_model.Dockerfile
+    environment:
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL-http://host.docker.internal:11434}
+      - LLM=llava
+    tty: true
+
   database:
     user: neo4j:neo4j
     image: neo4j:5.11

--- a/pull_model.Dockerfile
+++ b/pull_model.Dockerfile
@@ -26,7 +26,7 @@ COPY <<EOF pull_model.clj
         (async/go-loop [n 0]
           (let [[v _] (async/alts! [done (async/timeout 5000)])]
             (if (= :stop v) :stopped (do (println (format "... pulling model (%ss) - will take several minutes" (* n 10))) (recur (inc n))))))
-        (process/shell {:env {"OLLAMA_HOST" url} :out :inherit :err :inherit} (format "bash -c './bin/ollama show %s --modelfile > /dev/null || ./bin/ollama pull %s'" llm llm))
+        (process/shell {:env {"OLLAMA_HOST" url "HOME" (System/getProperty "user.home")} :out :inherit :err :inherit} (format "bash -c './bin/ollama show %s --modelfile > /dev/null || ./bin/ollama pull %s'" llm llm))
         (async/>!! done :stop))
 
       (println "OLLAMA model only pulled if both LLM and OLLAMA_BASE_URL are set and the LLM model is not gpt")))


### PR DESCRIPTION
Adding a `describe_image` tool to describe/analyze/explain/extrapolate context and text from images using https://llava-vl.github.io/.

**_This feature was worked on as part of the [Hyland Alfresco TechQuest Hackathon 2024](https://hub.alfresco.com/t5/alfresco-content-services-blog/join-the-alfresco-techquest-hack-a-thon-2024-innovate/ba-p/383852)._**

_**NOTE**: it would be nice to experiment with streamed responses before merging a feature like this, as it feels pretty clunky otherwise. However, while with very minimal tinkering it was possible to achieve streaming responses, the quality of the responses themselves seemed to deteriorate so that requires some investigation as some parameters should most likely played with until good responses can be obtained even then._